### PR TITLE
Renames Tritonian Lungs

### DIFF
--- a/mods/species/tritonian/species.dm
+++ b/mods/species/tritonian/species.dm
@@ -27,5 +27,5 @@
 	appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_TONE_TRITON | HAS_LIPS | HAS_UNDERWEAR | HAS_EYE_COLOR
 
 /obj/item/organ/internal/lungs/gills
-	name = "tritonian lungs"
+	name = "lungs and gills"
 	has_gills = TRUE


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->

## Changelog
:cl:
tweak: Renames tritonian lungs to Lungs and Gills for skrell compatibility.
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

Fixes https://github.com/EscapePodNo5/EPN5-Neb/issues/93